### PR TITLE
优化日志提交逻辑 & Bug修复 & 全新Raft客户端

### DIFF
--- a/lu-raft-kv/src/main/java/cn/think/in/java/entity/AentryParam.java
+++ b/lu-raft-kv/src/main/java/cn/think/in/java/entity/AentryParam.java
@@ -22,6 +22,8 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.io.Serializable;
+
 /**
  *
  * 附加日志 RPC 参数. handlerAppendEntries
@@ -33,7 +35,7 @@ import lombok.ToString;
 @Setter
 @ToString
 @Builder
-public class AentryParam {
+public class AentryParam implements Serializable {
 
     /** 候选人的任期号  */
     private long term;

--- a/lu-raft-kv/src/main/java/cn/think/in/java/entity/Command.java
+++ b/lu-raft-kv/src/main/java/cn/think/in/java/entity/Command.java
@@ -16,10 +16,7 @@ limitations under the License.
  */
 package cn.think.in.java.entity;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 
 import java.io.Serializable;
 
@@ -31,6 +28,8 @@ import java.io.Serializable;
 @Setter
 @ToString
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class Command implements Serializable {
 
     String key;

--- a/lu-raft-kv/src/main/java/cn/think/in/java/entity/LogEntry.java
+++ b/lu-raft-kv/src/main/java/cn/think/in/java/entity/LogEntry.java
@@ -17,8 +17,10 @@ limitations under the License.
 package cn.think.in.java.entity;
 
 import cn.think.in.java.LogModule;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
 
@@ -30,6 +32,8 @@ import java.io.Serializable;
  */
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class LogEntry implements Serializable, Comparable {
 
     private Long index;

--- a/lu-raft-kv/src/main/java/cn/think/in/java/entity/RvoteParam.java
+++ b/lu-raft-kv/src/main/java/cn/think/in/java/entity/RvoteParam.java
@@ -22,6 +22,8 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.io.Serializable;
+
 /**
  * 请求投票 RPC 参数.
  *
@@ -32,7 +34,7 @@ import lombok.Setter;
 @Setter
 @Builder
 @Data
-public class RvoteParam {
+public class RvoteParam implements Serializable {
     /** 候选人的任期号  */
     private long term;
 

--- a/lu-raft-kv/src/main/java/cn/think/in/java/impl/DefaultStateMachine.java
+++ b/lu-raft-kv/src/main/java/cn/think/in/java/impl/DefaultStateMachine.java
@@ -142,7 +142,8 @@ public class DefaultStateMachine implements StateMachine {
             Command command = logEntry.getCommand();
 
             if (command == null) {
-                throw new IllegalArgumentException("command can not be null, logEntry : " + logEntry.toString());
+                // 忽略空日志
+                return;
             }
             String key = command.getKey();
             machineDb.put(key.getBytes(), JSON.toJSONBytes(logEntry));

--- a/lu-raft-kv/src/main/java/raft/client/RaftClientRPC.java
+++ b/lu-raft-kv/src/main/java/raft/client/RaftClientRPC.java
@@ -52,7 +52,7 @@ public class RaftClientRPC {
 
         String addr = list.get(index);
 
-        LogEntry response;
+        ClientKVAck response;
         Request r = Request.builder().obj(obj).url(addr).cmd(Request.CLIENT_REQ).build();
         try {
             response = CLIENT.send(r);
@@ -61,7 +61,7 @@ public class RaftClientRPC {
             response = CLIENT.send(r);
         }
 
-        return response;
+        return (LogEntry)response.getResult();
     }
 
     /**
@@ -76,14 +76,14 @@ public class RaftClientRPC {
         ClientKVReq obj = ClientKVReq.builder().key(key).value(value).type(ClientKVReq.PUT).build();
 
         Request r = Request.builder().obj(obj).url(addr).cmd(Request.CLIENT_REQ).build();
-        String response;
+        ClientKVAck response;
         try {
-            response = CLIENT.send(r);
+            response = (ClientKVAck)CLIENT.send(r);
         } catch (Exception e) {
             r.setUrl(list.get((int) ((count.incrementAndGet()) % list.size())));
-            response = CLIENT.send(r);
+            response = (ClientKVAck)CLIENT.send(r);
         }
 
-        return response;
+        return response.getResult().toString();
     }
 }

--- a/lu-raft-kv/src/main/java/raft/client/RaftClientWithCommandLine.java
+++ b/lu-raft-kv/src/main/java/raft/client/RaftClientWithCommandLine.java
@@ -1,0 +1,66 @@
+package raft.client;
+
+import cn.think.in.java.entity.LogEntry;
+import lombok.extern.slf4j.Slf4j;
+
+import java.net.InetAddress;
+import java.util.Scanner;
+import java.util.UUID;
+
+/**
+ * Created by 大东 on 2023/2/25.
+ */
+@Slf4j
+public class RaftClientWithCommandLine {
+
+    public static void main(String[] args) throws Throwable {
+
+        RaftClientRPC rpc = new RaftClientRPC();
+
+        // 从键盘接收数据
+        Scanner scan = new Scanner(System.in);
+
+        // nextLine方式接收字符串
+        System.out.println("Raft client is running, please input command:");
+
+        while (scan.hasNextLine()){
+            String input = scan.nextLine();
+            if (input.equals("exit")){
+                scan.close();
+                return;
+            }
+            String[] raftArgs = input.split(" ");
+            int n = raftArgs.length;
+            if (n != 2 && n != 3){
+                System.out.println("invalid input");
+                continue;
+            }
+
+            // get [key]
+            if (n == 2){
+                if (!raftArgs[0].equals("get")){
+                    System.out.println("invalid input");
+                    continue;
+                }
+                LogEntry logEntry = rpc.get(raftArgs[1]);
+                if (logEntry == null || logEntry.getCommand() == null){
+                    System.out.println("null");
+                } else {
+                    System.out.println(logEntry.getCommand().getValue());
+                }
+
+            }
+
+            // [op] [key] [value]
+            if (n == 3){
+                if (raftArgs[0].equals("put")){
+                    System.out.println(rpc.put(raftArgs[1], raftArgs[2]));
+                } else {
+                    System.out.println("invalid input");
+                }
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
非常感谢莫那·鲁道给我们提供了如此优秀的raft开源项目！   
我是raft的初学者大东，在学习您的项目的过程中，我发现了该项目存在一定的优化空间，于是我对代码进行了一些增改，希望能达到锦上添花的效果。下面是我对优化点的说明：   

## 日志提交

### 问题描述

在原项目中，跟随者接收到 append entry 请求后，会立即将日志内容应用到状态机，个人认为这种做法有风险。

假设日志还未分发到多数节点时，【领导者A】宕机，并且下一任【领导者B】恰好不含该日志，那么该日志将会在【领导者B】发出它的 append entry 请求时被清除。但原先持有该日志的节点已经将其应用到状态机了，并且无法撤销 `apply`。所以，该机制会导致状态机数据与日志数据的不一致。

这种不一致一方面会导致我们无法通过日志准确地恢复出状态机的数据，不利于备份和分析；另一方面，若后期对项目进行扩展，让跟随者承担一部分“读操作”的职责时，会产生严重的数据不一致问题。

### 优化

跟随者提交日志的逻辑修改为：

1. 收到 append entry 请求
2. 若不是心跳请求，则写入本地日志
3. 与领导者同步 commit index，将 index ≤ commit index 的日志应用至状态机
4. 同意 append entry 请求

## no-op 空日志

### 问题描述

 <img src="https://user-images.githubusercontent.com/80438314/218472061-a862c36b-1543-4d2b-aac7-263863a86f57.png" alt="image-20230213201539539" width="450" />

1. 结论①：新领导者上任后不可直接提交旧领导者未提交的日志，即使其已被复制到多数节点；只能在提交自己任期的日志时间接提交旧日志
2. 论证①（反证法）：上图描述了一种可能会破坏数据**持久性**的情况。任期为2的领导者S1将日志复制到S2后宕机。紧接着任期为3的领导者S5上台，在本地写入了若干日志，然而还没来得及将日志复制到其它节点就宕机了。S1重新上线并恰好当选任期为4的领导者。在没有结论①约束的情况下，S1可以将任期为2的日志复制到S3并提交。如果此时S1宕机，那么S5必然会当选任期为5的领导者，因为它的日志任期是最大的。S5在将它的第3至第5条日志复制到S1~S3时，这些节点里任期为2的日志会被覆盖——这不符合已提交的日志不能被修改的要求。因此需要引入结论①来避免这种情况，该结论在部分raft资料里被称为“延迟提交”
3. 补充①：引入结论①看似很安全，但如果任期为4的领导者S1在上任后没有收到任何客户端的写请求，那么它将没有机会提交任期为2的日志，发出该写请求的客户端会因此而阻塞——这不符合raft的**可用性**要求

### 优化

引入 no-op 空日志来解决补充①里提到的可用性问题：

1. 新领导者上任后，立即向 raft 集群写入一条 `command` 为 null 的日志并提交
2. 这条日志只有索引和任期信息，不会改变状态机的数据
3. 空日志属于领导者任期的日志，其提交之后，可以确保在此之前的日志都被正确提交。既能满足结论①的约束，又可以解决上述的可用性问题


## 客户端

### 优化

1. 实现了基于命令行交互的客户端：解析用户输入并返回处理结果
<img width="608" alt="客户端" src="https://user-images.githubusercontent.com/80438314/222949066-a4261751-ff51-4413-83f3-b841c16e3a56.png">

